### PR TITLE
Add default file extension for test option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var style2 = css`
 
 Regular expression or function which test importee for being parsed as style file (css).  
 Type: `RegExp | Function`  
-Default: `() => false`  
+Default: `/\.css$/`  
 Example: `/\.css$/` only `.css` imports will be parsed
 
 #### postcss

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -13,8 +13,8 @@ function run(source: string, options?: Partial<PluginOptions>, ...plugins_: any[
 }
 
 it('smoke', () => {
-    const result = run(`var foo = 1`);
-    expect(result).toEqual(`var foo = 1;`);
+    const result = run(`const foo = 1`);
+    expect(result).toEqual(`const foo = 1;`);
 });
 
 it('get styles single', () => {
@@ -27,7 +27,7 @@ it('get styles single', () => {
         },
     );
     expect(result).not.toEqual(expect.stringMatching(`import style from 'style.css'`));
-    expect(result).toEqual(expect.stringMatching('var style = "a {}";'));
+    expect(result).toEqual(expect.stringMatching('const style = "a {}";'));
 });
 
 it('styles with postcss option', () => {
@@ -41,7 +41,7 @@ it('styles with postcss option', () => {
         },
     );
     expect(result).toEqual(
-        `var style = "a { position: absolute; top: 50%; transform: translateY(-50%) }";`,
+        `const style = "a { position: absolute; top: 50%; transform: translateY(-50%) }";`,
     );
 });
 
@@ -55,8 +55,8 @@ it('get styles array', () => {
             readFileSync: (file: string) => `.${file.slice(-6, -4)} {}`,
         },
     );
-    expect(result).toEqual(expect.stringMatching('var style1 = ".p1 {}'));
-    expect(result).toEqual(expect.stringMatching('var style2 = ".p2 {}'));
+    expect(result).toEqual(expect.stringMatching('const style1 = ".p1 {}'));
+    expect(result).toEqual(expect.stringMatching('const style2 = ".p2 {}'));
 });
 
 it('side effect import', () => {
@@ -94,11 +94,11 @@ it('tagged template expression', () => {
         },
     );
     expect(result).toEqual(expect.stringMatching('import { css as _css } from "lit-element"'));
-    expect(result).toEqual(expect.stringMatching('var style = _css`a {}`'));
+    expect(result).toEqual(expect.stringMatching('const style = _css`a {}`'));
     expect(result).toEqual(
         expect.stringMatching(stripIndents`
         import { css as _css } from "lit-element";
-        var style = _css\`a {}\`;
+        const style = _css\`a {}\`;
     `),
     );
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export default function ({ types: t }: typeof babel, options: PluginOptions): Pl
             variableDeclaratorInit = t.stringLiteral(cssContent);
         }
         path.replaceWith(
-            t.variableDeclaration('var', [
+            t.variableDeclaration('const', [
                 t.variableDeclarator(t.identifier(defaultImportName), variableDeclaratorInit),
             ]),
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { dirname, resolve } from 'path';
 import { getCss } from './getcss';
 
 const defaultOptions = {
-    test: (() => false) as RegExp | Function,
+    test: /\.css$/ as RegExp | Function,
     readFileSync: undefined as Function | undefined,
     postcss: undefined as undefined | string | boolean,
     tagged: undefined as undefined | [string, string],


### PR DESCRIPTION
Hi @unlight 

I tried to use this plugin with the Babel CLI and a json file for the config (`babel.config.json`) and realized that the transform was not made because the `test` option was missing and it's not possible to use a RegExp or function in a json file.

With the proposed change, a RegExp to match CSS files with `.css` extension is used by default instead of a function, so it is not necessary to specify the `test` option unless you need to transform other kind of files. This way the plugin can be used with json config files. Maybe the `test` option could also accept an array of file extensions to allow specifying different extensions in json files.

Also the `var` keyword has been replaced by `const`.